### PR TITLE
Issue/7

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@ant-design/icons": "^5.1.3",
     "@stitches/react": "^1.2.8",
     "antd": "^5.4.7",
     "react": "^18.2.0",

--- a/src/App.css
+++ b/src/App.css
@@ -6,18 +6,4 @@
 .ant-layout {
   height: 100%;
 }
-.site-layout-content {
-  min-height: 280px;
-  padding: 24px;
-}
-#components-layout-demo-top .logo {
-  float: left;
-  width: 120px;
-  height: 31px;
-  margin: 16px 24px 16px 0;
-  background: rgba(255, 255, 255, 0.3);
-}
-.ant-row-rtl #components-layout-demo-top .logo {
-  float: right;
-  margin: 16px 0 16px 24px;
-}
+

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,37 +1,24 @@
-import { Layout, Menu } from "antd";
-import theme from "../style/theme";
+import { Layout, Avatar, Space, Typography } from 'antd';
+import theme from '../style/theme';
+import { UserOutlined } from '@ant-design/icons';
 
-const { Header, Content, Footer } = Layout;
+import Board from './components/Board';
+
+const { Header, Content } = Layout;
+const { Text } = Typography;
 
 const Home = () => {
   return (
     <Layout className="layout">
       <Header>
-        <div className="logo" />
-        <Menu
-          theme="dark"
-          mode="horizontal"
-          defaultSelectedKeys={["2"]}
-          items={new Array(5).fill(null).map((_, index) => {
-            const key = index + 1;
-            return {
-              key,
-              label: `nav ${key}`,
-            };
-          })}
-        />
+        <Space wrap>
+          <Avatar icon={<UserOutlined />} />
+          <Text style={{ color: theme.color.white }}>@soyoon</Text>
+        </Space>
       </Header>
-      <Content style={{ padding: "50px 50px" }}>
-        <div
-          className="site-layout-content"
-          style={{ background: theme.color.content }}
-        >
-          Content
-        </div>
+      <Content>
+        <Board />
       </Content>
-      <Footer style={{ textAlign: "center" }}>
-        Ant Design ©2023 Created by Ant UED
-      </Footer>
     </Layout>
   );
 };

--- a/src/pages/components/Board.tsx
+++ b/src/pages/components/Board.tsx
@@ -1,0 +1,78 @@
+import { Card, Row } from 'antd';
+import theme from '../../style/theme';
+
+import { styled } from '@stitches/react';
+import { useEffect, useState } from 'react';
+
+const BoardRow = styled(Row, {
+  gap: '0.25rem',
+  height: 'calc(25% - 0.25rem)',
+  marginBottom: '0.25rem',
+});
+
+const BoardCard = styled(Card, {
+  maxWidth: '33%',
+  height: '100%',
+  flex: '1',
+});
+
+type SelectedList = string[];
+
+const Board = () => {
+  const [selectedList, setSelectedList] = useState<SelectedList>([]);
+
+  const onClickCard = (event: React.MouseEvent<HTMLDivElement>) => {
+    const target = event.target as HTMLDivElement;
+    setSelectedList((list) => {
+      if (list.includes(target.innerText)) {
+        return list.filter((item) => item !== target.textContent);
+      }
+
+      const textContent = target.innerText.trim();
+      if (textContent) {
+        return [...list, textContent];
+      }
+      return list;
+    });
+  };
+
+  useEffect(() => {
+    console.log({ selectedList });
+  }, [selectedList]);
+
+  return (
+    <div
+      className="board-container"
+      style={{
+        background: theme.color.content,
+        padding: '1rem',
+        gap: '0.25rem',
+        height: '100%',
+      }}
+      onClick={onClickCard}
+    >
+      <BoardRow>
+        <BoardCard bordered={false}>🐧🐧</BoardCard>
+        <BoardCard bordered={false}>🐼🐼🐼</BoardCard>
+        <BoardCard bordered={false}>🐧</BoardCard>
+      </BoardRow>
+      <BoardRow>
+        <BoardCard bordered={false}>🐷</BoardCard>
+        <BoardCard bordered={false}>🦄🦄</BoardCard>
+        <BoardCard bordered={false}>🦄</BoardCard>
+      </BoardRow>
+      <BoardRow>
+        <BoardCard bordered={false}>🦋</BoardCard>
+        <BoardCard bordered={false}>🐷🐷</BoardCard>
+        <BoardCard bordered={false}>🐼🐼</BoardCard>
+      </BoardRow>
+      <BoardRow>
+        <BoardCard bordered={false}>🐧🐧🐧</BoardCard>
+        <BoardCard bordered={false}>🐼</BoardCard>
+        <BoardCard bordered={false}>🦋🦋</BoardCard>
+      </BoardRow>
+    </div>
+  );
+};
+
+export default Board;


### PR DESCRIPTION
### 요약 resolved #7 

<!-- 해당 PR이 무엇을 해결했는지 작성하세요. resolved 뒤에 이슈번호를 적어주세요. -->




### 변경 사항

<!-- 변경한 내용에 대해 자세히 설명하세요. -->
- @ant-design/icons 인스톨 : 아이콘같은거 가져다 쓰기 좋을 것 같아서 깔아보았습니다 de71e8531f0ae3ae3629f0bf513858a6474e68d6
- Board 컴포넌트 추가 c8eb5abefa4a18ea0baf0e8f893d8cf08bb236e1
- App.css에서 안쓰는 코드 제거 cd526d09a23d728d512cae9ef683ac9965548ae9

### 궁금한 점
- 처음 마운트될 때 렌더링이 두번되는 것 같은데 이거 정상인가요? 리액트 너무 오랜만이라 기억이 가물가물.. 
<img width="728" alt="스크린샷 2023-05-28 오후 9 52 01" src="https://github.com/sulrung-boardgame/set-front/assets/45188497/168bb14c-9fee-4c93-814e-4f60773e9382">
- 회사에서 'px'을 안쓰고 'rem'을 쓰고 있어서 나도 모르게 그렇게 했는데, 혹시 'px'을 쓰는게 더 편하다면 다음 커밋부터 그렇게 하도록 하겠습니당
- 타입스크립트 안써봐서 이상하게 쓴 부분이 있을 수 있는데 이상하면 꼭 좀 알려주세영. 공부하게 ㅠㅠ..

### 관련 이슈

<!-- 관련된 이슈가 있다면 이곳에 참조하세요. -->
